### PR TITLE
Wrap error handling and parsing with try catch - added test

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,7 @@ setup(
         'pytest',
         'pytest-cov',
         'tox',
+        'mock',
     ],
 )
 


### PR DESCRIPTION
This wraps the error parsing in queryservice.py with try catch and raises a EutilsNCBIError if there are any exceptions.