### PR TITLE
Bug in abstract property in Medlinecitation.py

### DIFF
--- a/eutils/xmlfacades/medlinecitation.py
+++ b/eutils/xmlfacades/medlinecitation.py
@@ -12,7 +12,7 @@ class MedlineCitation(eutils.xmlfacades.base.Base):
 
     @property
     def abstract(self):
-        return self._xml_root.findtext('Article/Abstract/AbstractText')
+        return '\n'.join([at.text for at in self._xml_root.findall('Article/Abstract/AbstractText')])
 
     @property
     def authors(self):


### PR DESCRIPTION
I have been deeply impressed by the convenience provided by eutils package and appreciate your contributions.
In the meantime, I found a bug in Medlinecitation.py.
In previous version, the abstract property did not show full text of an abstract in a case where there are multi AbstractText elements, (e.g. PMID: 22351513).
Therefore, I suggest using findall instead of findtext to find all elements.