### PR TITLE
efetch for protein db

### DIFF
--- a/eutils/client.py
+++ b/eutils/client.py
@@ -82,7 +82,7 @@ class Client(object):
         doc = le.XML(xml)
         if db in ['gene']:
             return EntrezgeneSet(doc)
-        if db in ['nuccore', 'nucest']:
+        if db in ['nuccore', 'nucest', 'protein']:
             # TODO: GBSet is misnamed; it should be GBSeq and get the GBSeq XML node as root (see gbset.py)
             return GBSet(doc)
         if db in ['pubmed']:

--- a/eutils/xmlfacades/gbseq.py
+++ b/eutils/xmlfacades/gbseq.py
@@ -182,26 +182,42 @@ class GBFeature(Base):
         return {q.findtext('GBQualifier_name'): q.findtext('GBQualifier_value')
                 for q in self._xml_root.findall('GBFeature_quals/GBQualifier')}
 
+    def get_qualifiers(self, name):
+        return self._xml_root.xpath(
+            'GBFeature_quals/GBQualifier[GBQualifier_name/text()="'+name+'"]/GBQualifier_value/text()')
+
+    def get_qualifier(self, name):
+        nodes = self.get_qualifiers(name)
+        assert len(nodes) <= 1, "Node has {n=n} {key} features! (expected <= 1 when using get_qualifier)".format(n=len(nodes), key=name)
+        if len(nodes)==0:
+            return None
+        return self.get_qualifiers(name)[0]
+
 
 class GBFeatureCDS(GBFeature):
 
     @property
     def translation(self):
-        return self._xml_root.xpath(
-            'GBFeature_quals/GBQualifier[GBQualifier_name/text()="translation"]/GBQualifier_value/text()')[0]
+        return self.get_qualifier('translation')
 
     @property
     def db_xrefs(self):
-        return self._xml_root.xpath(
-            'GBFeature_quals/GBQualifier[GBQualifier_name/text()="db_xref"]/GBQualifier_value/text()')
+        return self.get_qualifiers('db_xref')
+
+    @property
+    def gene(self):
+        return self.get_qualifier('gene')
+
+    @property
+    def gene_synonyms(self):
+        return (self.get_qualifier('gene_synonym') or "").split("; ")
 
 
 class GBFeatureExon(GBFeature):
 
     @property
     def inference(self):
-        return self._xml_root.xpath(
-            'GBFeature_quals/GBQualifier[GBQualifier_name/text()="inference"]/GBQualifier_value/text()')[0]
+        return self.get_qualifier('inference')
 
 
 if __name__ == "__main__":

--- a/eutils/xmlfacades/gbseq.py
+++ b/eutils/xmlfacades/gbseq.py
@@ -47,7 +47,10 @@ class GBSeq(Base):
 
     @property
     def gene(self):
-        return self.features.gene.qualifiers['gene']
+        gene = self.features.gene
+        if not gene:
+            return None
+        return gene.qualifiers['gene']
     
     @property
     def genes(self):


### PR DESCRIPTION
The protein db when queries by the API has a very similare xml structure to nuccore and nucest.
The PR thus use GBSet to fetch data, and extends GBSeq to prevent crashing as some GBQualifier are no present in all response of the three databases.