### PR TITLE
WIP - Medcitations qualifiers types

### DIFF
--- a/eutils/xmlfacades/medlinecitation.py
+++ b/eutils/xmlfacades/medlinecitation.py
@@ -30,6 +30,10 @@ class MedlineCitation(eutils.xmlfacades.base.Base):
         return [_format_author(au) for au in self._xml_root.xpath('Article/AuthorList/Author')]
 
     @property
+    def chemicals(self):
+        return self._xml_root.xpath('ChemicalList/Chemical/NameOfSubstance/text()')
+
+    @property
     def issue(self):
         return self._xml_root.findtext('Article/Journal/JournalIssue/Issue')
 
@@ -43,12 +47,20 @@ class MedlineCitation(eutils.xmlfacades.base.Base):
         return self._xml_root.xpath('MeshHeadingList/MeshHeading/DescriptorName/text()')
 
     @property
+    def mesh_qualifiers(self):
+        return self._xml_root.xpath('MeshHeadingList/MeshHeading/QualifierName/text()')
+
+    @property
     def pages(self):
         return self._xml_root.findtext('Article/Pagination/MedlinePgn')
 
     @property
     def pmid(self):
         return self._xml_root.findtext('PMID')
+
+    @property
+    def pub_types(self):
+        return self._xml_root.xpath('Article/PublicationTypeList/PublicationType/text()')
 
     @property
     def title(self):

--- a/eutils/xmlfacades/pubmedarticle.py
+++ b/eutils/xmlfacades/pubmedarticle.py
@@ -23,6 +23,10 @@ class PubmedArticle(eutils.xmlfacades.base.Base):
         return self._medline_citation.authors
 
     @property
+    def chemicals(self):
+        return self._medline_citation.chemicals
+
+    @property
     def issue(self):
         return self._medline_citation.issue
 
@@ -35,12 +39,20 @@ class PubmedArticle(eutils.xmlfacades.base.Base):
         return self._medline_citation.mesh_headings
 
     @property
+    def mesh_qualifiers(self):
+        return self._medline_citation.mesh_qualifiers
+
+    @property
     def pages(self):
         return self._medline_citation.pages
 
     @property
     def pmid(self):
         return self._medline_citation.pmid
+
+    @property
+    def pub_types(self):
+        return self._medline_citation.pub_types
 
     @property
     def title(self):

--- a/tests/data/cassettes/test_eutils_xmlfacades_pubmedarticle_22528466
+++ b/tests/data/cassettes/test_eutils_xmlfacades_pubmedarticle_22528466
@@ -1,0 +1,95 @@
+interactions:
+- request:
+    body: tool=eutils&email=biocommons-dev%40googlegroups.com&retmode=xml&usehistory=y&retmax=250&db=pubmed&id=22528466
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['109']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.19.1]
+    method: POST
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAHyRUU/CMBDH3/0Utc+yWycgMV2JrnvAMFgETXgyY2ukSdeSrUP99pZBQFDsy13u
+        f5f/7650+FkqtBFVLY0OMfF8jIbsil7zaTRfpDFKm2UpiofKylyJmbAofXkcjyKEOwCTcQLA53zb
+        lByabhCpLXpqtECBTwYA8QQjvLJ2Xd8DFLbwtCo9LVfeu9mAzpcS1q0JmMbu0zcy8Ps+8Vw3djTn
+        EOcldoXco45BSS0iaTPr1kEzF5s6xEnMx6NJjNH0Q4sqxI4b70basTQZcfR6OAFmQdALBt1+n8JW
+        +tHJMysiU66VsKI41lttIbKKuYVvKbTpqZoYbVfM71HYZacqz74Y6VLYxqMbXLBrMZ7FRtYXIe7+
+        gSDkMoQf/Anxy4zuD9/+vCmECnFaSW07sRK5rYyWOWbfAAAA///MWO1y27YSfRWM/1x5xpL4IUpi
+        rGiuIjupXMfxWE4zuf8gEpJ4SxIqCNpl3uq+yH2mHgCkTEl0EnXSun8SGVgs9uyeXexyV/0Vz0VK
+        491VvTObz2/ILMvS+2LDXp/UVdjewG37bn846iqphsOlWhzPGUHkWQgWRHny+mSWSiZSJk8OT+mT
+        v/A4T9jYgTvKn81yWvUYZDA/moXgB+Wo5l0tUYXGaQrNjqQJzgULGuO0Fes+e+eoW/dKw/59JJE0
+        94Km2YrB0USwDDYF61HXbDUF6cNksRAggs6t+uE7lnVUfHYFdqPfbQx/RSNz6eXvG9ihspDwJVlE
+        POarKKBxXBAayOiBkXWe0JREKrBLBooQGm/WlDhYIpOYM1XIKGzZUbt74y1dRWmDhcbzpoDcrtKx
+        7fb8toc8qq3tQXpO1ejymgd6HXXlchYaWoc8OiG/0DgKP9+8PvkMblsd27IG3cy2nd6wDWa0/b7d
+        b1ujbk3BvsMWmRTwRoPx1dY9+12O3zO55mFGUhbApVQUZMkFkWtGsjxQS8s8JlLFEOuJKZc0DUEE
+        xBROlGUUtl4lj0wwErIHFvMNC7VwjppAJCfMBE6rNyHaCC5ZlJ41xao1e3vz//85px1ifpAoI5Rk
+        LBCqzJGgkPxXOBzaqCSbmBZq+wE1PSaCo+Qg1rAyj2FjutJ3BiyO8bdQNN7wNGPKqIdI4ESULlFN
+        AKZDaoyF1lRmBtIWMe5eCp4Qxbg8I0EeyxwKoSKS0dP2l2LFwS7CkoUoeNYhu7RV9gDXxDHeVbqV
+        xVtXQ011O8UlPF1GenFRkLv79u30Tnu29EzpRi0awjuBNJJRkuQpX8RcQprGRRbBjp+05ydez9cO
+        QTgE02Y/RnK9tQaWUxVTkESRJdO86JM1jAzzANLsAE4thpmMEuV5yGlkXk+FOIwCEwydplvulK4g
+        WbSCkWp/Q+X6kRaIBbaeEtyci2RRndIWAryxqHSGcgLNMtjGFPX0fYq06qgKNfZoYcA+54Qn0CqS
+        C678guvwchlCb/J4gz2qGZNV1mRrrh0dIncWGfstZ6lETTLU2voXgnGhiZEGDEyPeVIgi0UI9mSK
+        jXlmcK+j1ZqhQ4pVLqk7tuiplCJa5JIuYk1hwQKeLFBjUll3gmKCSJAiOvkWjPQdj8w+dpOVtpir
+        TMnwoiktFYNa9/PbU03EOl7nzLaG5VEIVPvKDbD1kZOQ5qs1bqs4q3PyARmjOiyYX5BFHoYwJMzF
+        NhtR6ZGC2nlAnsk8LEyq0TjjNcrXKodBp/2TqZTMkHzb7DC3PlUiKA3oRjsJl1R8VXTYrT4mMA00
+        O9PgtdZa4alOSSqAr0JDNxzYEa4AihfsKQ1rvtpSpmKM9pZ6h+olee/1aK7ko0mOwi2uI9xYtX7l
+        e9FQ8bXszqPS3CpcA8ANRYdzzR9hnxh1tyvNB95ywfT2pyiOI5qMutuVZ5okXSTjbPwJnUD1u1l0
+        slxGsWkSZumSf6URqkmOwYyVYCq34viMzNKgc0Y8yyNTuokkj+GsXEhyc3lG5jm6QIwe1hn5RLM1
+        Aik5XqKLqVqznDPycT7pgBsaWPxvWVPcQb4hMrVrn2m9vokBIjo4PyhqIgp+/f6g/YwmLP3+kP38
+        tZD9WCD0UShPfz+UeZ4h7y6+H8z84m9D85nxxyMyiaXt+Tr/ckQqzY+HUq2qArK3c03TVU5XbMzS
+        lTK7/GuvPcarEZneU7Wth2qapMjH2euTC8vu95zhybjs9EnZhOs5pS79/frc3rB/Mr4rZxMk9mbD
+        hUQCd+Yd8o4//Au/b3javu38hJVvXHSw3eCi0mQ1VRH1z+FAemj7N+e6avbvPTvO6dHb2Z//y3A+
+        mVSfync+fJhbzJxSTX4HVWmECplKUYxvmHoC8EKF2ahbLe59KDC67id7Y952GsLO7ombOPmYRmiN
+        MLH4juXbDsaY+uKuuBrmr6MUff5qbPl9pz0c2r6Z8avlGtivQRtN1yxRr3tDOKutBo/fsRXkRXGT
+        JwsmxjB2b+XwiErZD8s5WkBJUcNKklqW74P0k20bOoG3JDy1J74f12bb/gaTp57Xsz2YbKaU7aSm
+        W6d/rtmqvAyVp2fbaaStJ8p/tMmW76KC3ap2EHOiGT7+eoMvp8TtOB2749p/ntee34fp7+I8yFXt
+        C2nG/oTlT2u7+TmqPtIqXUyOZ+8hubtUk+VJopJqyoUw03zWlO2HUqhZS1PD1ZfBrKl8Q2KOugIs
+        V+QdRlqp/uWwGNMa+sUBuWDBudtr2c7pK9vy3HZf06E61PCW7X9Ntoe25/XVJ9ndr8mlew6t/sG4
+        DPtu1wUsijvE9v0B+RDIc9v2WgDlOYO25zrHgnIcxx2qb6cvA2qq6CeIIhdXzxnwUZHQwCAc9s5t
+        p2WfvnL9du9YaP2+j7g7L4Vs78OqilefvKfFuddyT185ttseHglo2B+4tme9FKDL9EuRMHJrHhoN
+        yD3vDRT3fOd4MDZK6sB7KTCTzSYmbyIegHjqf8mCdapIhw7QJpONOLf7bmtw+mrYt47G5lhDb+A4
+        /kuBuyJPjyuZVt9hNQtRCgEvX507dmuIouF7KIRHFw0UQr/nvnAlnOvPkeQNW9MHHTeLvGWLc10M
+        bcdvm0fzGFi+77i+9WKwEDRyRVQHimdL8EXZguqgDXWpd51WD8XQ89r+0Y/XAKON92KUNCGbsjjG
+        sU2ZZu+pOHctVQ571qBte8emmW31+rb9YgXxivxnzf4bYQAnGI8eyDyIyJsyWqrQ+y1PBctuHwvM
+        Hnp4uQbuEcD+AAAA///cWt9vgjAQ/lcIzxJpSymdxmRZTGYyXdz24qOD6lhUCIh//9r6Y1NONpDI
+        Yngkvdx3vbt+97W1AgM6vdtxuMo9jLCFyxYWt4nteV5juadwHKjgrk0gW8FhnFseZuUbBZVF2Fji
+        jTJ/ISSvuPfDQK1MtaSiDy+bdDS9cJFVuqs7VBaU1xiqhyxJjOc4XBkDfS12OIzVaUXUbjm8fOPD
+        iFHcIGv/5ha7saQv28WL2Oiq8jqI3jmUWbwsxeCUERdV6RDg75OhbijSj0cxDcLVHBjQfvyFNDCR
+        +kkYr6NEDZkHdYXajim74meUvEVx6CtldmT21GVQt328BLA5zqaLcBaKb5NjaZIRdmpyYvYUo9OD
+        crd9tOzPZjGhgKfqmnQtW0ihVSVxnYlNtagpTQqIWk6kqhhBh+c2RUYw3o9g0bw4iHXDdVzPBeD2
+        z17EVgYu6RAAPEiyuSFm6jr4qvssvXGgnNMKhmgZmjwVY617K7RqBHh0LCNVjP4FFVZglTCoVpZi
+        PX2PFmG6vGoqu56NAG/0245f0rbu5KLyA1wZHN6eqDvy67qkFWDApZwk/N8TbNJUgm0V6TzGU4n6
+        Jg4GOQ8haEO3YJ/EdCNqPQpGzR0FclDCULVqqGlryyF3jymHUaCcCuosk0kzTAdhl3AA9qsQQfWt
+        vYQg1t6FCdjydiKWFouDTJPxG8lkxG0Gdai9Ln5ByVIbm8YXAAAA///CMLgAMjNCZtmEIozo9MAn
+        rWGTWlBhyLYFl8SSRCQjPIDa8jEm4SGbKqCLvEEL7WHbGYCdr9TMstQUfKsRDAmsRgAtV8C3GgE0
+        qIZlNQKKm4h1b2IysB1egt+9BFdPGON3L2jQllruBXaNilKrKHEtoaUe2AIXLOsB7MiDthqAaSym
+        Z+aVAv1hADQewqKGdyE7bkaMd3Mh+RKff7Fu4UHyL/ZdPHD/Ys07NPQv0Dz0AgR5RRXE43YFBSCh
+        4gyUdVBQOYQ+6LoizxTcq6M8UxRgexpgSQexYQquhqBe0H4IfHsgsJiEJIhc0iKXqTAefH0Uugho
+        9xgAAAD//wMAWIIpgfU2AAA=
+    headers:
+      Access-Control-Allow-Origin: ['*']
+      Cache-Control: [private]
+      Connection: [Keep-Alive]
+      Content-Security-Policy: [upgrade-insecure-requests]
+      Content-Type: [text/xml; charset=UTF-8]
+      Date: ['Wed, 14 Nov 2018 14:41:19 GMT']
+      Keep-Alive: ['timeout=1, max=10']
+      NCBI-PHID: [322CFEA86A528025000023E9671C4C83.1.1.m_5]
+      NCBI-SID: [DC9FB779F3EB0FC2_06A2SID]
+      Server: [Finatra]
+      Set-Cookie: ['ncbi_sid=DC9FB779F3EB0FC2_06A2SID; domain=.nih.gov; path=/; expires=Thu,
+          14 Nov 2019 14:41:20 GMT']
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains; preload]
+      Transfer-Encoding: [chunked]
+      X-RateLimit-Limit: ['100']
+      X-RateLimit-Remaining: ['99']
+      X-UA-Compatible: [IE=Edge]
+      X-XSS-Protection: [1; mode=block]
+      content-encoding: [gzip]
+      l5d-success-class: ['1.0']
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/test_eutils_xmlfacades_pubmedarticle.py
+++ b/tests/test_eutils_xmlfacades_pubmedarticle.py
@@ -1,5 +1,61 @@
 import vcr
 
+@vcr.use_cassette
+def test_eutils_xmlfacades_pubmedarticle_22528466(client):
+    pas = client.efetch(db="pubmed", id=22528466)
+    pa = next(iter(pas))
+
+    assert pa.abstract.startswith(u'Methods necessary for the successful transformation and regeneration of Aloe vera were developed and used to express the human protein, interferon alpha 2 (IFN\u03b12).')
+    assert set(pa.authors) == set(["Lowther W",
+                                   "Lorick K",
+                                   "Lawrence SD",
+                                   "Yeow WS"])
+    assert set(pa.chemicals) == set(["Antiviral Agents",
+                                     "IFNA2 protein, human",
+                                     "Interferon-alpha",
+                                     "Plant Extracts",
+                                     "Glucuronidase"])
+    assert pa.doi == "10.1007/s11248-012-9616-0"
+    assert pa.issue == "6"
+    assert pa.jrnl == "Transgenic Res."
+    assert set(pa.mesh_headings) == set(["Aloe",
+                                         "Antiviral Agents",
+                                         "Encephalomyocarditis virus",
+                                         "Genome, Plant",
+                                         "Glucuronidase",
+                                         "Humans",
+                                         "Immunoblotting",
+                                         "Interferon-alpha",
+                                         "Plant Extracts",
+                                         "Plant Leaves",
+                                         "Plants, Genetically Modified",
+                                         "Seeds",
+                                         "Signal Transduction",
+                                         "Transgenes"])
+    assert set(pa.mesh_qualifiers) == set(["chemistry",
+                                           "genetics",
+                                           "pharmacology",
+                                           "drug effects",
+                                           "genetics",
+                                           "metabolism",
+                                           "genetics",
+                                           "metabolism",
+                                           "pharmacology",
+                                           "drug effects",
+                                           "genetics",
+                                           "chemistry",
+                                           "drug effects",
+                                           "physiology"])
+    assert pa.pages == "1349-57"
+    assert pa.pii is None
+    assert pa.pmc is None
+    assert pa.pmid == "22528466"
+    assert set(pa.pub_types) == set(["Journal Article",
+                                    "Research Support, U.S. Gov't, Non-P.H.S."])
+    assert pa.title == "Expression of biologically active human interferon alpha 2 in Aloe vera."
+    assert pa.volume == "21"
+    assert pa.year == "2012"
+    assert "PubmedArticle(22528466" in str(pa)
 
 @vcr.use_cassette
 def test_eutils_xmlfacades_pubmedarticle_20412080(client):
@@ -8,6 +64,7 @@ def test_eutils_xmlfacades_pubmedarticle_20412080(client):
 
     assert pa.abstract.startswith('A standardized, controlled vocabulary allows phenotypic')
     assert set(pa.authors) == set(['Robinson PN', 'Mundlos S'])
+    assert set(pa.chemicals) == set([])
     assert pa.doi == '10.1111/j.1399-0004.2010.01436.x'
     assert pa.issue == '6'
     assert pa.jrnl == 'Clin. Genet.'
@@ -18,10 +75,12 @@ def test_eutils_xmlfacades_pubmedarticle_20412080(client):
                                           'Humans',
                                           'Phenotype',
                                           'Vocabulary, Controlled'])
+    assert set(pa.mesh_qualifiers) == set(["methods"])
     assert pa.pages == '525-34'
     assert pa.pii == 'CGE1436'
     assert pa.pmc is None
     assert pa.pmid == '20412080'
+    assert set(pa.pub_types) == set(["Journal Article", "Review"])
     assert pa.title == 'The human phenotype ontology.'
     assert pa.volume == '77'
     assert pa.year == '2010'
@@ -53,5 +112,3 @@ def test_eutils_xmlfacades_pubmedarticle_29915538(client):
     assert "Semaglutide" in pa.abstract
     assert "Results" in pa.abstract
     assert "P < 0.001" in pa.abstract
-
-


### PR DESCRIPTION
When parsing `MedlineCitation`, adding to `PubmedArticle` class:
- `mesh_qualifiers`: (list) extract mesh qualifiers (possible duplicates)
- `pub_types`: (list) publication types as listed [here](https://www.ncbi.nlm.nih.gov/books/NBK3827/table/pubmedhelp.T.publication_types/)
- `chemicals`: (list) List of substances

Test have been updated + new test (pmid: 22528466) has been created
