### PR TITLE
Expose SQLiteCache

### DIFF
--- a/src/eutils/__init__.py
+++ b/src/eutils/__init__.py
@@ -10,6 +10,7 @@ from ._versionwarning import *
 # flake8: noqa
 from ._internal.client import Client
 from ._internal.exceptions import EutilsError, EutilsNCBIError, EutilsNotFoundError, EutilsRequestError
+from ._internal.sqlitecache import SQLiteCache
 from ._internal.queryservice import QueryService
 from ._internal.versionwarning import warnings
 

--- a/tests/test_eutils_imports.py
+++ b/tests/test_eutils_imports.py
@@ -1,0 +1,37 @@
+import pytest
+
+
+def test_import_client():
+    try:
+        # flake8: noqa
+        from eutils import Client
+    except Exception:
+        pytest.fail("Client was unable to be imported")
+
+def test_import_exceptions():
+    try:
+        # flake8: noqa
+        from eutils import EutilsError, EutilsNCBIError, EutilsNotFoundError, EutilsRequestError
+    except Exception as exc:
+        pytest.fail(f"An exception was unable to be imported: {exc}")
+
+def test_import_sqllitecache():
+    try:
+        # flake8: noqa
+        from eutils import SQLiteCache
+    except Exception:
+        pytest.fail("SQLiteCache was unable to be imported")
+
+def test_import_queryservice():
+    try:
+        # flake8: noqa
+        from eutils import QueryService
+    except Exception:
+        pytest.fail("QueryService was unable to be imported")
+
+def test_import_warnings():
+    try:
+        # flake8: noqa
+        from eutils import warnings
+    except Exception:
+        pytest.fail("warnings were unable to be imported")


### PR DESCRIPTION
In the last version SQLiteCache was removed from being exposed from the top level package.  This change exposes it again.

Also, adds tests to ensure this doesn't happen again.